### PR TITLE
chore: exclude workflow directories from pre-commit hooks

### DIFF
--- a/.pre-commit-config.yaml
+++ b/.pre-commit-config.yaml
@@ -141,6 +141,8 @@ exclude: |
   (?x)(
     ^\.git/|
     ^\.github/|
+    ^\.claude/|
+    ^\.specify/|
     ^vendor/|
     ^dist/|
     .*\.tfstate$|


### PR DESCRIPTION
## Summary

Excludes `.claude/` and `.specify/` directories from pre-commit hook processing to prevent conflicts with workflow automation tooling.

## Problem

Pre-commit hooks were attempting to modify files in workflow automation directories:
```
Trim Trailing Whitespace.................................................Failed
- files were modified by this hook
Fixing .claude/commands/speckit.specify.md
Fixing .specify/scripts/bash/check-prerequisites.sh
...
```

These directories contain files managed by external tooling (speckit, slash commands) that should remain untouched.

## Solution

Added exclusion patterns to `.pre-commit-config.yaml`:
```yaml
exclude: |
  (?x)(
    ^\.git/|
    ^\.github/|
    ^\.claude/|      # ← Added
    ^\.specify/|     # ← Added
    ^vendor/|
    ^dist/|
    ...
  )
```

## Changes

| File | Lines | Change |
|------|-------|--------|
| `.pre-commit-config.yaml` | 144-145 | Add `^\.claude/` and `^\.specify/` to exclude pattern |

## Testing

### Before
```bash
make pre-commit-run
# Trim Trailing Whitespace.....Failed (modified 8 files in .claude/ and .specify/)
# Fix End of Files.............Failed (modified 3 files in .specify/)
```

### After
```bash
make pre-commit-run
# Trim Trailing Whitespace.....Passed ✅
# Fix End of Files.............Passed ✅
```

## Impact

- ✅ Workflow automation files remain untouched by formatting hooks
- ✅ No conflicts between pre-commit and workflow tooling
- ✅ Clean pre-commit runs for all development work
- ✅ Standard project files (.go, .tf, docs/) still validated normally

## Checklist

- [x] Exclusion patterns added
- [x] Pre-commit hooks tested and passing
- [x] No impact on code quality checks (only affects workflow dirs)
- [x] Commit message follows conventional commits

---

**Ready for review and merge** ✅