### PR TITLE
refactor: remove unused DER certificate validation code

### DIFF
--- a/internal/client/certificates.go
+++ b/internal/client/certificates.go
@@ -10,7 +10,6 @@ import (
 	"io"
 	"net/http"
 	"strings"
-	"time"
 
 	"github.com/cyberark/ark-sdk-golang/pkg/common"
 	"github.com/cyberark/ark-sdk-golang/pkg/common/isp"
@@ -149,7 +148,7 @@ type CertificateMetadata struct {
 // All fields use snake_case matching API contract (✅ VALIDATED via API testing).
 //
 // Required Fields:
-//   - CertBody: PEM or DER encoded certificate content
+//   - CertBody: PEM encoded certificate content
 //
 // Optional Fields:
 //   - CertName, CertDescription, CertType, DomainName, Labels
@@ -268,38 +267,6 @@ func ValidatePEMCertificate(pemData string) error {
 
 	// Basic sanity check: cert object was created successfully
 	_ = cert // Use cert variable to avoid unused error
-
-	return nil
-}
-
-// ValidateDERCertificate validates DER-encoded certificate content.
-// DER is binary ASN.1 format (typically base64-encoded in API requests).
-//
-// Validation Steps:
-//  1. Attempt X.509 parse directly (DER is raw ASN.1)
-//  2. Verify no private key material
-//  3. ❌ NO EXPIRATION CHECK (deferred to API)
-//
-// Parameters:
-//   - derData: DER-encoded certificate bytes (decoded from base64 if needed)
-//
-// Returns:
-//   - error: Validation failure
-//   - nil: Certificate is valid
-func ValidateDERCertificate(derData []byte) error {
-	// 1. X.509 parse (DER is raw ASN.1, no PEM wrapper)
-	cert, err := x509.ParseCertificate(derData)
-	if err != nil {
-		return fmt.Errorf("failed to parse DER certificate: %w", err)
-	}
-
-	// 2. Basic sanity checks
-	if cert.NotBefore.After(cert.NotAfter) {
-		return fmt.Errorf("certificate has invalid validity period: NotBefore (%s) is after NotAfter (%s)",
-			cert.NotBefore.Format(time.RFC3339), cert.NotAfter.Format(time.RFC3339))
-	}
-
-	// 3. ❌ SKIP expiration check (defer to SIA API - Issue #13)
 
 	return nil
 }

--- a/internal/client/errors.go
+++ b/internal/client/errors.go
@@ -374,7 +374,7 @@ func MapCertificateError(err error, operation string) diag.Diagnostic {
 			fmt.Sprintf("Certificate validation failed.\n\n"+
 				"Error: %s\n\n"+
 				"Recommended actions:\n"+
-				"1. Verify cert_body contains valid PEM or DER encoded certificate\n"+
+				"1. Verify cert_body contains valid PEM encoded certificate\n"+
 				"2. Ensure certificate does not contain private key material\n"+
 				"3. Check certificate is not expired or corrupted", errorMsg),
 		)


### PR DESCRIPTION
## Summary
Removes unused DER certificate validation code from the CyberArk SIA Terraform provider. The provider only supports PEM certificates (validated at the schema level), but there was legacy DER validation code that was never used.

## Changes
- ✅ Remove `ValidateDERCertificate()` function from `internal/client/certificates.go` (lines 275-305)
- ✅ Remove unused `"time"` import (only needed by deleted DER validation)
- ✅ Update `CertificateCreateRequest` comment from "PEM or DER" to "PEM only"
- ✅ Update error message in `MapCertificateError` from "PEM or DER" to "PEM only"

## Verification
- ✅ Schema validator still enforces PEM-only: `stringvalidator.OneOf("PEM")` in `internal/provider/certificate_resource.go`
- ✅ Documentation correctly states PEM-only support in `docs/resources/certificate.md`
- ✅ No broken references to removed code
- ✅ Build succeeds: `go build -v`
- ✅ All pre-commit hooks pass (go fmt, go vet, golangci-lint, etc.)

## Impact
- **Code Reduction**: Removes 32 lines of unused code
- **Clarity**: Clarifies that only PEM certificates are supported (no DER)
- **No Breaking Changes**: No user-facing changes; purely internal cleanup

## Test Plan
- [x] Code compiles successfully
- [x] Pre-commit hooks pass
- [x] No references to `ValidateDERCertificate` exist in codebase
- [x] PEM-only validation still enforced at schema level