### PR TITLE
docs: document failed target_set SDK refactor attempt

### DIFF
--- a/docs/development/ark-sdk-sia-services-analysis.md
+++ b/docs/development/ark-sdk-sia-services-analysis.md
@@ -395,12 +395,23 @@ These services are **available in ARK SDK v1.5.0** but are **NOT suitable for Te
 
 ### Priority 1: DELETE Panic Bug ⚠️ **CRITICAL** - ✅ **PROVEN**
 
-**Validation Status**: ✅ **REPRODUCED IN PRODUCTION** - CyberArk's own CLI panics with this bug
+**Validation Status**: ✅ **REPRODUCED IN PRODUCTION & PoCs**
+- CyberArk's own CLI panics with this bug (tested 2025-11-02)
+- Dual independent PoCs confirmed (tested 2025-11-15)
+  - Primary PoC: `/tmp/target-sets-poc/`
+  - Codex PoC: `/tmp/target-sets-poc-codex/`
+
 **CyberArk CLI Testing**: Confirmed `delete-secret` and `delete-target-set` crash with identical panic (nil pointer dereference in `http.NewRequestWithContext`). **CRITICAL: The API call NEVER succeeds and resources are NOT deleted** - panic occurs during HTTP request construction, BEFORE the request is sent to the API.
 
+**PoC Validation (2025-11-15)**:
+- ✅ **Both PoCs**: VM Secret DELETE panics with nil pointer dereference
+- ✅ **Both PoCs**: Target Set DELETE panics with nil pointer dereference
+- ✅ **Both PoCs**: Panic occurs in `bytes.(*Buffer).Len` called from `http.NewRequestWithContext`
+- ✅ **Both PoCs**: Workarounds using ISP client with empty body `{}` succeed
+
 **Affected Services**:
-- `SecretsVM().DeleteSecret()` ✅ Confirmed in CLI: `ark exec sia secrets vm delete-secret`
-- `WorkspacesTargetSets().DeleteTargetSet()` ✅ Confirmed in CLI: `ark exec sia workspaces target-sets delete-target-set`
+- `SecretsVM().DeleteSecret()` ✅ Confirmed in CLI + both PoCs
+- `WorkspacesTargetSets().DeleteTargetSet()` ✅ Confirmed in CLI + both PoCs
 - Potentially `VM().DeletePolicy()` (verify if uses `BaseDeletePolicy()`)
 
 **Root Cause**:
@@ -587,9 +598,13 @@ func (s *ArkSIASecretsVMService) listSecretsWithFilter(...) {
 
 ---
 
-### Priority 3: Target Sets Name-as-ID Quirk ⚠️ **DESIGN PATTERN**
+### Priority 3: Target Sets Name-as-ID and UPDATE Behavior ⚠️ **DESIGN PATTERN** - ✅ **VALIDATED 2025-11-15**
+
+**Validation Status**: ✅ **CONFIRMED via dual independent PoCs** - Both primary and Codex PoCs validated behavior
 
 **Affected Service**: `WorkspacesTargetSets()`
+
+#### Name-as-ID Pattern
 
 **SDK Pattern**:
 - API returns `name` field (string)
@@ -624,7 +639,111 @@ resource "cyberarksia_target_set" "example" {
 }
 ```
 
-**Discovery Credit**: Codex (SDK implementation analysis)
+#### UPDATE Behavior and omitempty Tags
+
+**Validation Testing** - Dual PoC Results (2025-11-15):
+
+**PoC 1 (Primary)** `/tmp/target-sets-poc/`:
+- ✅ UPDATE with all fields populated: **SUCCESS**
+- Initial test with partial fields: 403 error (later determined to be test setup issue)
+
+**PoC 2 (Codex)** `/tmp/target-sets-poc-codex/`:
+- ✅ UPDATE with all fields populated: **SUCCESS**
+- ❌ UPDATE with only Description field: **500 Internal Server Error**
+- **Root cause identified**: `mapstructure.Decode()` honors `omitempty` tags
+
+**SDK Implementation Analysis**:
+
+The SDK's `UpdateTargetSet()` method (line 180-215 in `ark_sia_workspaces_target_sets_service.go`):
+1. Uses `mapstructure.Decode()` to convert struct to map
+2. Removes `id` field from map
+3. Sends map as JSON body via PUT request
+
+**The `ArkSIAUpdateTargetSet` model** has `omitempty` tags on all fields except `ID`:
+```go
+type ArkSIAUpdateTargetSet struct {
+    ID                          string `json:"id"` // No omitempty
+    Name                        string `json:"name,omitempty"` // Dropped if ""
+    Description                 string `json:"description,omitempty"` // Dropped if ""
+    ProvisionFormat             string `json:"provision_format,omitempty"` // Dropped if ""
+    EnableCertificateValidation bool   `json:"enable_certificate_validation,omitempty"` // Dropped if false
+    SecretType                  string `json:"secret_type,omitempty"` // Dropped if ""
+    SecretID                    string `json:"secret_id,omitempty"` // Dropped if ""
+    Type                        string `json:"type,omitempty"` // Dropped if ""
+}
+```
+
+**Impact**:
+- Zero-value fields are omitted from JSON payload
+- Partial updates fail with API validation errors (500)
+- **SDK method WORKS when all fields are populated**
+
+**Provider Workaround Analysis**:
+
+Current implementation uses `UpdateTargetSetDirect()` workaround. **This workaround is REQUIRED and cannot be removed.**
+
+**❌ Failed Refactor Attempt (2025-11-15)**:
+
+Attempted to use SDK's `UpdateTargetSet()` method directly (Option B below) based on PoC validation showing "SDK works when all fields populated". The refactor FAILED with 3 test failures:
+
+1. **TestAccTargetSet_descriptionUpdate**: "Provider produced inconsistent result - description was null, but now cty.StringVal(\"Updated description\")"
+2. **TestAccTargetSet_certValidation**: "Provider produced inconsistent result - enable_certificate_validation was cty.False, but now cty.True"
+3. **TestAccTargetSet_provisionFormatNoClearing**: "expected an error but got none"
+
+**Root Cause** (confirmed by Codex analysis):
+- SDK's `omitempty` tags drop ALL zero values: `""` for strings, `false` for booleans
+- Even explicit `Description: ""` or `EnableCertificateValidation: false` are omitted from JSON
+- API interprets missing fields as "leave unchanged"
+- Users cannot clear descriptions or set booleans to false using the SDK struct
+- State fallback approach violates Terraform's plan contract (plan must match result)
+
+**PoC Limitation**: PoCs only tested non-clearing updates (all fields stayed populated). They didn't test:
+- Clearing description to empty string
+- Setting enable_certificate_validation to false
+- Removing provision_format
+
+**Option A (REQUIRED)**: Use workaround with manual map building
+```go
+updateRequest := map[string]interface{}{
+    "name":        plan.Name.ValueString(),
+    "description": plan.Description.ValueString(), // Sends "" to clear
+    "enable_certificate_validation": false, // Sends false explicitly
+    // ... all fields explicitly included
+}
+result, err := client.UpdateTargetSetDirect(ctx, authCtx, oldName, updateRequest)
+```
+
+**Option B (DOES NOT WORK)**: ~~Use SDK method with all fields from state/plan~~
+```go
+// ❌ FAILS - omitempty drops zero values, preventing field clearing
+updateReq := &targetsetmodels.ArkSIAUpdateTargetSet{
+    ID:                          state.Name.ValueString(),
+    Name:                        plan.Name.ValueString(),
+    Description:                 "", // DROPPED by omitempty
+    EnableCertificateValidation: false, // DROPPED by omitempty
+    // ...
+}
+updated, err := siaAPI.WorkspacesTargetSets().UpdateTargetSet(updateReq)
+```
+
+**Recommendation**: The workaround MUST remain until the SDK is fixed.
+
+**Why Workaround Cannot Be Removed**:
+- ❌ SDK's `omitempty` tags drop zero values even when explicitly set
+- ❌ Cannot clear descriptions (send empty string)
+- ❌ Cannot set enable_certificate_validation to false
+- ❌ Users need ability to clear/disable fields
+- ❌ Terraform plan contract requires exact planned values to be applied
+
+**When SDK Can Be Used (Future)**:
+- ✅ SDK removes `omitempty` tags from mutable fields
+- ✅ SDK uses pointer types for optional fields (`*string`, `*bool`)
+- ✅ Or we create custom struct without `omitempty` for updates
+
+**Discovery Credit**:
+- Initial PoC validation: Primary + Codex (2025-11-15)
+- Refactor failure analysis: Claude + Codex (2025-11-15)
+- Root cause (omitempty blocking zero values): Codex deep analysis
 
 ---
 
@@ -1055,10 +1174,14 @@ The ARK SDK v1.5.0 analysis identified 9 SIA services. The Terraform provider cu
 
 ---
 
-**Document Version**: 1.8 (Implementation Status Updated)
-**Last Updated**: 2025-11-14
-**Research Methodology**: Multi-perspective (Claude + Gemini + Codex) with SDK source code validation + **CyberArk ark CLI production testing**
+**Document Version**: 1.9 (PoC Validation & UPDATE Analysis)
+**Last Updated**: 2025-11-15
+**Research Methodology**: Multi-perspective (Claude + Gemini + Codex) with SDK source code validation + **CyberArk ark CLI production testing** + **Dual independent PoCs**
 **Implementation Update**: VM Secrets and Target Sets implemented and moved to "Currently Implemented" section
+**PoC Validation (2025-11-15)**:
+- Primary PoC: `/tmp/target-sets-poc/` - Full CRUD validation, SDK method testing
+- Codex PoC: `/tmp/target-sets-poc-codex/` - Independent validation, partial update failure proof
+- Key Finding: UpdateTargetSet() SDK method works when all fields populated (workaround unnecessary for providers)
 **ARK SDK Version Analyzed**: v1.5.0
 **Validation Status**:
 - ✅ All services confirmed against CyberArk's official `ark` CLI at `/home/tim/go/bin/ark`
@@ -1083,7 +1206,7 @@ The ARK SDK v1.5.0 analysis identified 9 SIA services. The Terraform provider cu
 | Database Workspaces | Resource | ✅ Implemented | Medium | `sia/workspaces/db/` | ✅ Workaround | 60+ database engines, DeleteDatabaseWorkspaceDirect |
 | Database Secrets | Resource | ✅ Implemented | Low-Medium | `sia/secrets/db/` | ✅ Workaround | Username/password, AWS IAM, DeleteSecretDirect |
 | VM Secrets | Resource | ✅ Implemented | Medium | `sia/secrets/vm/` | ✅ Workaround | ProvisionerUser/PCloudAccount, DeleteVMSecretDirect, ChangeVMSecretDirect |
-| Target Sets | Resource | ✅ Implemented | Medium | `sia/workspaces/targetsets/` | ✅ Workaround | Name-as-ID pattern, DeleteTargetSetDirect, UpdateTargetSetDirect |
+| Target Sets | Resource | ✅ Implemented | Medium | `sia/workspaces/targetsets/` | ⚠️ Partial | Name-as-ID pattern, DeleteTargetSetDirect (required), UpdateTargetSetDirect (optional - can use SDK) |
 | Certificates | Resource | ✅ Implemented | Low | `certificates` (custom client) | N/A | TLS/mTLS certificates |
 | Database Policies | Resource | ✅ Implemented | High | `uap/sia/db/` | ✅ Workaround | Access policies with time conditions, DeleteDatabasePolicyDirect |
 | Policy Assignments | Resource | ✅ Implemented | Medium | `uap/sia/db/` | N/A | Principal & workspace assignments (Read-Modify-Write pattern) |


### PR DESCRIPTION
## Summary

Documents a failed attempt to refactor the `cyberarksia_target_set` resource's Update() method to use the SDK's native `UpdateTargetSet()` method instead of the `UpdateTargetSetDirect()` workaround.

## Background

Based on PoC validation showing "SDK works when all fields populated", we attempted to simplify the code by using the SDK method directly. The refactor failed with 3 test failures, revealing that the SDK's `omitempty` tags make it impossible to clear fields or set booleans to false.

## Key Findings (via Codex analysis)

1. **SDK's omitempty tags drop ALL zero values**
   - Even explicit `Description: ""` or `EnableCertificateValidation: false` are omitted from JSON
   - API interprets missing fields as "leave unchanged"
   - Users cannot clear descriptions or disable certificate validation

2. **State fallback violates Terraform contract**
   - Terraform requires plan values to match applied values exactly
   - Using state as fallback for null/false plan values causes "inconsistent result" errors

3. **PoC limitation discovered**
   - PoCs only tested non-clearing updates (all fields stayed populated)
   - Didn't test clearing descriptions, setting booleans to false, or removing optional fields

## Test Failures

- `TestAccTargetSet_descriptionUpdate`: "Provider produced inconsistent result - description was null, but now cty.StringVal"
- `TestAccTargetSet_certValidation`: "Provider produced inconsistent result - enable_certificate_validation was cty.False, but now cty.True"
- `TestAccTargetSet_provisionFormatNoClearing`: "expected an error but got none"

## Conclusion

The `UpdateTargetSetDirect()` workaround MUST remain until:
- CyberArk removes `omitempty` tags from SDK's `ArkSIAUpdateTargetSet` struct, OR
- SDK uses pointer types for optional fields (`*string`, `*bool`), OR
- We implement a custom struct without `omitempty` for updates

## Changes

- Updated `docs/development/ark-sdk-sia-services-analysis.md` with:
  - Failed refactor attempt details
  - Root cause analysis
  - Why workaround cannot be removed
  - Future SDK fix requirements

## Related Work

The actual refactor attempt occurred on branch `refactor/target-set-use-sdk-update-method` but was reverted. This PR contains only the documentation of lessons learned.