### PR TITLE
docs: improve VM policy documentation for users and LLM maintainers

### DIFF
--- a/CLAUDE.md
+++ b/CLAUDE.md
@@ -445,6 +445,56 @@ updated, err := siaAPI.AccessPolicies().UpdatePolicy(policyID, newPolicy)
    - Reality: Required for ZSP/JIT access provisioning
    - Document this requirement in examples
 
+### Cloud VM Policy Target Format Requirements
+
+#### AWS (`aws_targets`)
+
+1. **Account IDs** - 12-digit number:
+   ```
+   123456789012
+   ```
+
+2. **VPC IDs** - `vpc-` prefix followed by 8 or 17-character alphanumeric string:
+   ```
+   vpc-12345678
+   vpc-1234567890abcdef0
+   ```
+
+#### Azure (`azure_targets`)
+
+1. **Subscription IDs** - UUID format (32 alphanumeric chars in 5 groups with hyphens):
+   ```
+   759a039e-dc44-4762-9f40-2696323c2fa5
+   ```
+
+2. **Resource Groups** - Full ARM path format:
+   ```
+   /subscriptions/<subscription-id>/resourceGroups/<resource-group-name>
+   ```
+   Example: `/subscriptions/759a039e-dc44-4762-9f40-2696323c2fa5/resourceGroups/my-rg`
+
+3. **VNet IDs** - Full ARM path format:
+   ```
+   /subscriptions/<subscription-id>/resourceGroups/<rg-name>/providers/Microsoft.Network/virtualNetworks/<vnet-name>
+   ```
+   Example: `/subscriptions/759a039e-dc44-4762-9f40-2696323c2fa5/resourceGroups/my-rg/providers/Microsoft.Network/virtualNetworks/my-vnet`
+
+**Common Error**: Using just the resource group name (e.g., `my-rg`) instead of the full ARM path will result in API validation error: `invalid azure resource group`.
+
+#### GCP (`gcp_targets`)
+
+1. **Project IDs** - 3-60 characters, lowercase letters/numbers/hyphens, must start with letter, end with letter or number:
+   ```
+   my-project-123
+   production-workloads
+   ```
+
+2. **VPC Network IDs** - Full VPC path format:
+   ```
+   projects/{project_id}/global/networks/{network_name}
+   ```
+   Example: `projects/my-project-123/global/networks/my-vpc`
+
 ### Policy Management Constraints
 
 1. **UpdatePolicy() Accepts ONE Workspace Type Only**

--- a/examples/resources/cyberarksia_vm_policy/aws_policy.tf
+++ b/examples/resources/cyberarksia_vm_policy/aws_policy.tf
@@ -1,5 +1,9 @@
 # AWS cloud VM access policy example
 # Demonstrates AWS-specific target criteria: regions, tags, VPC IDs, account IDs
+#
+# AWS Target Format Requirements:
+#   account_ids: 12-digit number (e.g., "123456789012")
+#   vpc_ids:     "vpc-" + 8 or 17 alphanumeric chars (e.g., "vpc-12345678")
 
 data "cyberarksia_principal" "cloud_admin" {
   name = "cloud-admin@example.com"
@@ -13,12 +17,12 @@ resource "cyberarksia_vm_policy" "aws_production" {
   description   = "Access policy for AWS production EC2 instances"
 
   # Initial principal assignment
-  principal {
-    principal_id          = data.cyberarksia_principal.cloud_admin.principal_id
-    principal_name        = data.cyberarksia_principal.cloud_admin.principal_name
+  principals {
+    principal_id          = data.cyberarksia_principal.cloud_admin.id
+    principal_name        = data.cyberarksia_principal.cloud_admin.name
     principal_type        = data.cyberarksia_principal.cloud_admin.principal_type
-    source_directory_name = data.cyberarksia_principal.cloud_admin.source_directory_name
-    source_directory_id   = data.cyberarksia_principal.cloud_admin.source_directory_id
+    source_directory_name = data.cyberarksia_principal.cloud_admin.directory_name
+    source_directory_id   = data.cyberarksia_principal.cloud_admin.directory_id
   }
 
   # SSH connection behavior

--- a/examples/resources/cyberarksia_vm_policy/azure_policy.tf
+++ b/examples/resources/cyberarksia_vm_policy/azure_policy.tf
@@ -1,5 +1,10 @@
 # Azure Cloud VM Access Policy Example
 # Demonstrates Azure-specific target criteria
+#
+# Azure Target Format Requirements:
+#   subscriptions:   UUID format (e.g., "759a039e-dc44-4762-9f40-2696323c2fa5")
+#   resource_groups: Full ARM path (e.g., "/subscriptions/<id>/resourceGroups/<name>")
+#   vnet_ids:        Full ARM path (e.g., "/subscriptions/<id>/resourceGroups/<rg>/providers/Microsoft.Network/virtualNetworks/<name>")
 
 data "cyberarksia_principal" "azure_admin" {
   name = "azure-admin@example.com"
@@ -12,12 +17,12 @@ resource "cyberarksia_vm_policy" "azure_production" {
   status        = "Active"
   description   = "Access policy for Azure production virtual machines"
 
-  principal {
-    principal_id          = data.cyberarksia_principal.azure_admin.principal_id
-    principal_name        = data.cyberarksia_principal.azure_admin.principal_name
+  principals {
+    principal_id          = data.cyberarksia_principal.azure_admin.id
+    principal_name        = data.cyberarksia_principal.azure_admin.name
     principal_type        = data.cyberarksia_principal.azure_admin.principal_type
-    source_directory_name = data.cyberarksia_principal.azure_admin.source_directory_name
-    source_directory_id   = data.cyberarksia_principal.azure_admin.source_directory_id
+    source_directory_name = data.cyberarksia_principal.azure_admin.directory_name
+    source_directory_id   = data.cyberarksia_principal.azure_admin.directory_id
   }
 
   # SSH for Linux VMs
@@ -42,10 +47,10 @@ resource "cyberarksia_vm_policy" "azure_production" {
       value = ["Engineering", "Operations"]
     }
 
-    # Resource groups
+    # Resource groups (MUST use full ARM path format)
     resource_groups = [
-      "rg-production-east",
-      "rg-production-west"
+      "/subscriptions/759a039e-dc44-4762-9f40-2696323c2fa5/resourceGroups/rg-production-east",
+      "/subscriptions/759a039e-dc44-4762-9f40-2696323c2fa5/resourceGroups/rg-production-west"
     ]
 
     # Virtual networks
@@ -54,8 +59,8 @@ resource "cyberarksia_vm_policy" "azure_production" {
       "/subscriptions/sub-123/resourceGroups/rg-prod/providers/Microsoft.Network/virtualNetworks/vnet-prod-west"
     ]
 
-    # Azure subscriptions
-    subscriptions = ["subscription-id-123", "subscription-id-456"]
+    # Azure subscriptions (UUID format)
+    subscriptions = ["759a039e-dc44-4762-9f40-2696323c2fa5", "a1b2c3d4-5678-90ab-cdef-1234567890ab"]
   }
 
   max_session_duration = 4

--- a/examples/resources/cyberarksia_vm_policy/complete.tf
+++ b/examples/resources/cyberarksia_vm_policy/complete.tf
@@ -20,20 +20,20 @@ resource "cyberarksia_vm_policy" "comprehensive" {
   time_zone     = "America/New_York"
 
   # Multiple initial principals (minimum 1 required)
-  principal {
-    principal_id          = data.cyberarksia_principal.admin.principal_id
-    principal_name        = data.cyberarksia_principal.admin.principal_name
+  principals {
+    principal_id          = data.cyberarksia_principal.admin.id
+    principal_name        = data.cyberarksia_principal.admin.name
     principal_type        = data.cyberarksia_principal.admin.principal_type
-    source_directory_name = data.cyberarksia_principal.admin.source_directory_name
-    source_directory_id   = data.cyberarksia_principal.admin.source_directory_id
+    source_directory_name = data.cyberarksia_principal.admin.directory_name
+    source_directory_id   = data.cyberarksia_principal.admin.directory_id
   }
 
-  principal {
-    principal_id          = data.cyberarksia_principal.ops_team.principal_id
-    principal_name        = data.cyberarksia_principal.ops_team.principal_name
+  principals {
+    principal_id          = data.cyberarksia_principal.ops_team.id
+    principal_name        = data.cyberarksia_principal.ops_team.name
     principal_type        = data.cyberarksia_principal.ops_team.principal_type
-    source_directory_name = data.cyberarksia_principal.ops_team.source_directory_name
-    source_directory_id   = data.cyberarksia_principal.ops_team.source_directory_id
+    source_directory_name = data.cyberarksia_principal.ops_team.directory_name
+    source_directory_id   = data.cyberarksia_principal.ops_team.directory_id
   }
 
   # Both SSH and RDP (supported simultaneously)
@@ -71,9 +71,9 @@ resource "cyberarksia_vm_policy" "comprehensive" {
     }
 
     vpc_ids = [
-      "vpc-prod-1",
-      "vpc-prod-2",
-      "vpc-staging-1"
+      "vpc-0a1b2c3d4e5f67890",
+      "vpc-0b2c3d4e5f678901a",
+      "vpc-0c3d4e5f6789012ab"
     ]
 
     account_ids = ["123456789012", "210987654321"]
@@ -120,8 +120,8 @@ output "comprehensive_delegation" {
 
 output "comprehensive_created_by" {
   value = {
-    user = cyberarksia_vm_policy.comprehensive.created_by.user
-    date = cyberarksia_vm_policy.comprehensive.created_by.date
+    user      = cyberarksia_vm_policy.comprehensive.created_by.user
+    timestamp = cyberarksia_vm_policy.comprehensive.created_by.timestamp
   }
   description = "Policy creation metadata"
 }

--- a/examples/resources/cyberarksia_vm_policy/gcp_policy.tf
+++ b/examples/resources/cyberarksia_vm_policy/gcp_policy.tf
@@ -1,5 +1,9 @@
 # GCP Cloud VM Access Policy Example
 # Demonstrates GCP-specific target criteria (note: uses "labels" not "tags")
+#
+# GCP Target Format Requirements:
+#   projects: 3-60 chars, lowercase letters/numbers/hyphens (e.g., "my-project-123")
+#   vpc_ids:  Full path format (e.g., "projects/<project>/global/networks/<network>")
 
 data "cyberarksia_principal" "gcp_admin" {
   name = "gcp-admin@example.com"
@@ -12,12 +16,12 @@ resource "cyberarksia_vm_policy" "gcp_production" {
   status        = "Active"
   description   = "Access policy for GCP production compute instances"
 
-  principal {
-    principal_id          = data.cyberarksia_principal.gcp_admin.principal_id
-    principal_name        = data.cyberarksia_principal.gcp_admin.principal_name
+  principals {
+    principal_id          = data.cyberarksia_principal.gcp_admin.id
+    principal_name        = data.cyberarksia_principal.gcp_admin.name
     principal_type        = data.cyberarksia_principal.gcp_admin.principal_type
-    source_directory_name = data.cyberarksia_principal.gcp_admin.source_directory_name
-    source_directory_id   = data.cyberarksia_principal.gcp_admin.source_directory_id
+    source_directory_name = data.cyberarksia_principal.gcp_admin.directory_name
+    source_directory_id   = data.cyberarksia_principal.gcp_admin.directory_id
   }
 
   # SSH for GCE instances

--- a/examples/resources/cyberarksia_vm_policy/rdp_policy.tf
+++ b/examples/resources/cyberarksia_vm_policy/rdp_policy.tf
@@ -13,12 +13,12 @@ resource "cyberarksia_vm_policy" "windows_servers" {
   description   = "RDP access to Windows domain servers"
 
   # Initial principal
-  principal {
-    principal_id          = data.cyberarksia_principal.windows_admin.principal_id
-    principal_name        = data.cyberarksia_principal.windows_admin.principal_name
+  principals {
+    principal_id          = data.cyberarksia_principal.windows_admin.id
+    principal_name        = data.cyberarksia_principal.windows_admin.name
     principal_type        = data.cyberarksia_principal.windows_admin.principal_type
-    source_directory_name = data.cyberarksia_principal.windows_admin.source_directory_name
-    source_directory_id   = data.cyberarksia_principal.windows_admin.source_directory_id
+    source_directory_name = data.cyberarksia_principal.windows_admin.directory_name
+    source_directory_id   = data.cyberarksia_principal.windows_admin.directory_id
   }
 
   # RDP behavior with domain ephemeral user
@@ -54,12 +54,12 @@ resource "cyberarksia_vm_policy" "workgroup_servers" {
   status        = "Active"
   description   = "RDP access to standalone Windows servers"
 
-  principal {
-    principal_id          = data.cyberarksia_principal.windows_admin.principal_id
-    principal_name        = data.cyberarksia_principal.windows_admin.principal_name
+  principals {
+    principal_id          = data.cyberarksia_principal.windows_admin.id
+    principal_name        = data.cyberarksia_principal.windows_admin.name
     principal_type        = data.cyberarksia_principal.windows_admin.principal_type
-    source_directory_name = data.cyberarksia_principal.windows_admin.source_directory_name
-    source_directory_id   = data.cyberarksia_principal.windows_admin.source_directory_id
+    source_directory_name = data.cyberarksia_principal.windows_admin.directory_name
+    source_directory_id   = data.cyberarksia_principal.windows_admin.directory_id
   }
 
   # RDP with local ephemeral user

--- a/examples/resources/cyberarksia_vm_policy/resource.tf
+++ b/examples/resources/cyberarksia_vm_policy/resource.tf
@@ -14,12 +14,12 @@ resource "cyberarksia_vm_policy" "basic_servers" {
   description   = "Access policy for production on-premises servers"
 
   # Required: At least one principal assignment at policy creation
-  principal {
-    principal_id          = data.cyberarksia_principal.vm_admin.principal_id
-    principal_name        = data.cyberarksia_principal.vm_admin.principal_name
+  principals {
+    principal_id          = data.cyberarksia_principal.vm_admin.id
+    principal_name        = data.cyberarksia_principal.vm_admin.name
     principal_type        = data.cyberarksia_principal.vm_admin.principal_type
-    source_directory_name = data.cyberarksia_principal.vm_admin.source_directory_name
-    source_directory_id   = data.cyberarksia_principal.vm_admin.source_directory_id
+    source_directory_name = data.cyberarksia_principal.vm_admin.directory_name
+    source_directory_id   = data.cyberarksia_principal.vm_admin.directory_id
   }
 
   # Connection behavior: SSH with specific username

--- a/templates/resources/vm_policy.md.tmpl
+++ b/templates/resources/vm_policy.md.tmpl
@@ -38,6 +38,34 @@ For cloud-specific and RDP configurations, see:
 - [GCP Policy](../../examples/resources/cyberarksia_vm_policy/gcp_policy.tf) - Projects, VPCs, labels
 - [RDP Policy](../../examples/resources/cyberarksia_vm_policy/rdp_policy.tf) - Local/domain ephemeral users
 
+## Cloud Target Format Requirements
+
+When targeting cloud resources, use these exact formats:
+
+### AWS (`aws_targets`)
+
+| Field | Format | Example |
+|-------|--------|---------|
+| `account_ids` | 12-digit number | `123456789012` |
+| `vpc_ids` | `vpc-` + 8 or 17 alphanumeric chars | `vpc-12345678`, `vpc-0a1b2c3d4e5f6789a` |
+
+### Azure (`azure_targets`)
+
+| Field | Format | Example |
+|-------|--------|---------|
+| `subscriptions` | UUID (32 chars in 5 hyphen-separated groups) | `759a039e-dc44-4762-9f40-2696323c2fa5` |
+| `resource_groups` | Full ARM path | `/subscriptions/<id>/resourceGroups/<name>` |
+| `vnet_ids` | Full ARM path | `/subscriptions/<id>/resourceGroups/<rg>/providers/Microsoft.Network/virtualNetworks/<name>` |
+
+**Common Error**: Using just the resource group name (e.g., `my-rg`) instead of the full ARM path results in: `invalid azure resource group`.
+
+### GCP (`gcp_targets`)
+
+| Field | Format | Example |
+|-------|--------|---------|
+| `projects` | 3-60 chars, lowercase letters/numbers/hyphens | `my-project-123` |
+| `vpc_ids` | Full path format | `projects/<project>/global/networks/<network>` |
+
 ## Troubleshooting
 
 | Error | Cause | Resolution |
@@ -46,3 +74,4 @@ For cloud-specific and RDP configurations, see:
 | "at least 1 principal" | Cannot remove last principal | Add another principal first, or delete the policy |
 | "unsupported workspace type" | Azure policy SDK limitation | Provider handles this automatically |
 | Multiple target blocks | Only one location type allowed | Use exactly one of: `fqdn_ip_targets`, `aws_targets`, `azure_targets`, or `gcp_targets` |
+| "invalid azure resource group" | Wrong format for resource_groups | Use full ARM path: `/subscriptions/<id>/resourceGroups/<name>` |


### PR DESCRIPTION
## Summary

- Add cloud target format requirements section to CLAUDE.md and vm_policy template
- Fix all 6 VM policy examples to use correct schema (principals block, data source attributes)
- Add troubleshooting entry for Azure resource group format error

## Changes

### CLAUDE.md & vm_policy.md.tmpl
Added "Cloud VM Policy Target Format Requirements" section documenting:
- **AWS**: `account_ids` (12-digit), `vpc_ids` (vpc-xxx format)
- **Azure**: `subscriptions` (UUID), `resource_groups` (full ARM path), `vnet_ids` (ARM path)
- **GCP**: `projects` (lowercase), `vpc_ids` (full path)

### Example Files (all 6)
- Block name: `principal` → `principals` (matches actual resource schema)
- Data source attributes:
  - `.principal_id` → `.id`
  - `.principal_name` → `.name`
  - `.source_directory_name` → `.directory_name`
  - `.source_directory_id` → `.directory_id`
- `complete.tf`: Fixed invalid VPC IDs, `.created_by.date` → `.created_by.timestamp`
- Cloud examples: Added format header comments

## Test plan
- [x] Verified examples match actual resource/data source schemas
- [x] Pre-commit hooks passed (terraform fmt, etc.)