### PR TITLE
chore: prepare v0.2.0 release

### DIFF
--- a/.github/CODEOWNERS
+++ b/.github/CODEOWNERS
@@ -1,0 +1,22 @@
+# CODEOWNERS - Defines code owners for pull request reviews
+# https://docs.github.com/en/repositories/managing-your-repositorys-settings-and-features/customizing-your-repository/about-code-owners
+
+# Default owners for everything in the repo
+* @aaearon
+
+# Provider implementation
+/internal/provider/ @aaearon
+
+# Client and SDK integration
+/internal/client/ @aaearon
+
+# Documentation
+/docs/ @aaearon
+
+# Examples
+/examples/ @aaearon
+
+# CI/CD and build configuration
+/.github/ @aaearon
+/.goreleaser.yml @aaearon
+/Makefile @aaearon

--- a/.github/pull_request_template.md
+++ b/.github/pull_request_template.md
@@ -1,0 +1,51 @@
+## Description
+
+<!-- Briefly describe what this PR does and why -->
+
+## Type of Change
+
+<!-- Check all that apply -->
+
+- [ ] Bug fix (non-breaking change that fixes an issue)
+- [ ] New feature (non-breaking change that adds functionality)
+- [ ] Breaking change (fix or feature that would cause existing functionality to change)
+- [ ] Documentation update
+- [ ] Refactoring (no functional changes)
+- [ ] Test addition or improvement
+
+## Related Issues
+
+<!-- Link any related issues: Fixes #123, Relates to #456 -->
+
+## Testing
+
+<!-- Describe the tests you ran or added -->
+
+- [ ] Unit tests pass (`go test ./...`)
+- [ ] Acceptance tests pass (`TF_ACC=1 go test ./...`)
+- [ ] Manual testing completed (describe below)
+
+### Manual Testing Steps
+
+<!-- If applicable, describe how to manually test this change -->
+
+## Checklist
+
+- [ ] My code follows the project's coding standards
+- [ ] I have run `make validate` and all checks pass
+- [ ] I have updated the documentation (if applicable)
+- [ ] I have added tests that prove my fix/feature works
+- [ ] New and existing tests pass locally
+- [ ] Any dependent changes have been merged and published
+
+## Breaking Changes
+
+<!-- If this is a breaking change, describe the impact and migration path -->
+
+## Screenshots
+
+<!-- If applicable, add screenshots to help explain your changes -->
+
+## Additional Notes
+
+<!-- Any additional information that reviewers should know -->

--- a/.goreleaser.yml
+++ b/.goreleaser.yml
@@ -93,12 +93,12 @@ release:
 
     Download the appropriate binary for your platform from the assets below.
 
-    For detailed installation instructions, see the [README](https://github.com/aaearon/terraform-provider-cyberark-sia#installation).
+    For detailed installation instructions, see the [README](https://github.com/aaearon/terraform-provider-cyberarksia#installation).
 
   footer: |
     ---
 
-    **Full Changelog**: https://github.com/aaearon/terraform-provider-cyberark-sia/compare/{{ .PreviousTag }}...{{ .Tag }}
+    **Full Changelog**: https://github.com/aaearon/terraform-provider-cyberarksia/compare/{{ .PreviousTag }}...{{ .Tag }}
 
 snapshot:
   name_template: '{{ incpatch .Version }}-next'

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -7,20 +7,78 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 
 ## [Unreleased]
 
+## [0.2.0] - 2025-11-26
+
 ### BREAKING CHANGES
 
-1. **Resource Rename**: `cyberarksia_database_policy_database_assignment` has been renamed to `cyberarksia_database_policy_workspace_assignment` for better consistency with other resource names
+1. **Provider Schema**: Renamed provider attribute `client_secret` to `password` for improved clarity
+   - Update your provider configuration blocks: change `client_secret` to `password`
+   - Example: `provider "cyberarksia" { password = var.password }`
+
+2. **Environment Variable**: Renamed `CYBERARK_CLIENT_SECRET` to `CYBERARK_PASSWORD`
+   - Update environment variables in CI/CD pipelines and local development
+   - Update `.env` files and Terraform variable references
+
+3. **Resource Rename**: `cyberarksia_database_policy_database_assignment` has been renamed to `cyberarksia_database_policy_workspace_assignment` for better consistency with other resource names
    - **Rationale**: The new name follows the established pattern where assignment resources are named after their base resource (e.g., `cyberarksia_database_workspace`)
    - **Action Required**: Update Terraform state and configuration files (see migration guide below)
 
-2. **Resource Rename**: `cyberarksia_secret` has been renamed to `cyberarksia_database_secret` to accurately reflect that it manages database credentials only (not VM secrets)
+4. **Resource Rename**: `cyberarksia_secret` has been renamed to `cyberarksia_database_secret` to accurately reflect that it manages database credentials only (not VM secrets)
 
-3. **AWS IAM Schema**: New required fields for AWS IAM authentication:
+5. **AWS IAM Schema**: New required fields for AWS IAM authentication:
    - `aws_account` (string, 12 digits) - AWS account number
    - `aws_username` (string) - IAM username from ARN
    - These fields are now **required** when `authentication_type = "aws_iam"`
 
+### Added
+
+- **VM policy resource** (`cyberarksia_vm_policy`) with multi-cloud support
+  - AWS targets: Account IDs, VPC IDs
+  - Azure targets: Subscription IDs, Resource Groups, VNet IDs
+  - GCP targets: Project IDs, VPC Network IDs
+  - On-premises: FQDN/IP targets
+  - SSH and RDP protocol support
+  - Time-based access windows and session limits
+- **VM policy principal assignment resource** (`cyberarksia_vm_policy_principal_assignment`)
+  - Assign users, groups, or roles to VM policies
+  - Supports inline and separate assignment patterns
+- **Target set resource** (`cyberarksia_target_set`)
+  - Group VMs/servers by domain, suffix, or target matching
+  - Integration with VM secrets for credential management
+- **Virtual machine secret resource** (`cyberarksia_virtual_machine_secret`)
+  - ProvisionerUser: Username/password credentials for VM provisioning
+  - PCloudAccount: Reference to PAM vault accounts
+- **PR template**: Standardized pull request format
+- **CODEOWNERS**: Automated reviewer assignment
+
+### Changed
+
+- All examples updated to use `password` attribute
+- All documentation updated to reference `password` terminology
+- Error messages now use "username or password" terminology instead of "client_id or client_secret"
+- Renamed `cyberarksia_secret` resource to `cyberarksia_database_secret` in all:
+  - Resource implementation
+  - Examples and documentation
+  - Test files
+
+### Fixed
+
+- **database_policy_workspace_assignment**: Improved error messages when API rejects deletion due to constraint violations (≥1 target required). The Delete() method now translates cryptic API errors like "List should have at least 1 item" into clear, actionable guidance for users.
+- **database_policy_principal_assignment**: Improved error messages when API rejects deletion due to constraint violations (≥1 principal required). Provides clear resolution steps when attempting to remove the last principal from a policy.
+- **GoReleaser**: Fixed incorrect repository URLs in release notes
+
 ### Migration Guide
+
+#### Provider Configuration
+
+1. **Update Provider Configuration**: Change `client_secret` attribute to `password` in all `provider "cyberarksia"` blocks
+2. **Update Environment Variables**: Rename `CYBERARK_CLIENT_SECRET` to `CYBERARK_PASSWORD` in:
+   - Shell environment (`export CYBERARK_PASSWORD="..."`)
+   - CI/CD pipeline secrets
+   - Terraform Cloud/Enterprise workspace variables
+   - `.env` files
+3. **Update Terraform Variables**: Rename any variables like `cyberark_client_secret` to `cyberark_password`
+4. **Update Scripts**: Search for `CYBERARK_CLIENT_SECRET` in automation scripts and update to `CYBERARK_PASSWORD`
 
 #### Policy Database Assignment Rename
 
@@ -111,7 +169,7 @@ resource "cyberarksia_database_secret" "example" {
 
 #### Step 3: Update AWS IAM Secrets (If Applicable)
 
-⚠️ **IMPORTANT**: If you use AWS IAM authentication (`authentication_type = "aws_iam"`), you MUST add the new required fields or your configuration will fail validation.
+If you use AWS IAM authentication (`authentication_type = "aws_iam"`), you MUST add the new required fields or your configuration will fail validation.
 
 **Before (will fail validation):**
 ```hcl
@@ -120,7 +178,7 @@ resource "cyberarksia_database_secret" "rds_iam" {
   authentication_type   = "aws_iam"
   aws_access_key_id     = "AKIAIOSFODNN7EXAMPLE"
   aws_secret_access_key = "wJalrXUtnFEMI/K7MDENG/bPxRfiCYEXAMPLEKEY"
-  # ❌ Missing required fields - will cause error!
+  # Missing required fields - will cause error!
 }
 ```
 
@@ -131,50 +189,14 @@ resource "cyberarksia_database_secret" "rds_iam" {
   authentication_type   = "aws_iam"
   aws_access_key_id     = "AKIAIOSFODNN7EXAMPLE"
   aws_secret_access_key = "wJalrXUtnFEMI/K7MDENG/bPxRfiCYEXAMPLEKEY"
-  aws_account           = "123456789012"        # ✅ NEW: Your 12-digit AWS account number
-  aws_username          = "database-admin"      # ✅ NEW: IAM username from ARN
+  aws_account           = "123456789012"        # NEW: Your 12-digit AWS account number
+  aws_username          = "database-admin"      # NEW: IAM username from ARN
 }
 ```
 
 **Finding your AWS account and username:**
 - `aws_account`: Your 12-digit AWS account ID (e.g., "123456789012")
 - `aws_username`: The IAM username portion from your ARN (e.g., if ARN is `arn:aws:iam::123456789012:user/database-admin`, use `"database-admin"`)
-
-### Changed
-- Renamed `cyberarksia_secret` resource to `cyberarksia_database_secret` in all:
-  - Resource implementation
-  - Examples and documentation
-  - Test files
-
-### Fixed
-- **database_policy_workspace_assignment**: Improved error messages when API rejects deletion due to constraint violations (≥1 target required). The Delete() method now translates cryptic API errors like "List should have at least 1 item" into clear, actionable guidance for users.
-- **database_policy_principal_assignment**: Improved error messages when API rejects deletion due to constraint violations (≥1 principal required). Provides clear resolution steps when attempting to remove the last principal from a policy.
-
-## [0.2.0] - 2025-11-01
-
-### BREAKING CHANGES
-- **Provider Schema**: Renamed provider attribute `client_secret` to `password` for improved clarity
-  - Update your provider configuration blocks: change `client_secret` to `password`
-  - Example: `provider "cyberarksia" { password = var.password }`
-- **Environment Variable**: Renamed `CYBERARK_CLIENT_SECRET` to `CYBERARK_PASSWORD`
-  - Update environment variables in CI/CD pipelines and local development
-  - Update `.env` files and Terraform variable references
-- **Documentation**: Updated security recommendations to reference CyberArk Conjur instead of Terraform Cloud/HashiCorp Vault
-
-### Migration Guide
-1. **Update Provider Configuration**: Change `client_secret` attribute to `password` in all `provider "cyberarksia"` blocks
-2. **Update Environment Variables**: Rename `CYBERARK_CLIENT_SECRET` to `CYBERARK_PASSWORD` in:
-   - Shell environment (`export CYBERARK_PASSWORD="..."`)
-   - CI/CD pipeline secrets
-   - Terraform Cloud/Enterprise workspace variables
-   - `.env` files
-3. **Update Terraform Variables**: Rename any variables like `cyberark_client_secret` to `cyberark_password`
-4. **Update Scripts**: Search for `CYBERARK_CLIENT_SECRET` in automation scripts and update to `CYBERARK_PASSWORD`
-
-### Changed
-- All examples updated to use `password` attribute
-- All documentation updated to reference `password` terminology
-- Error messages now use "username or password" terminology instead of "client_id or client_secret"
 
 ## [0.1.2] - 2025-11-01
 
@@ -193,7 +215,6 @@ resource "cyberarksia_database_secret" "rds_iam" {
   - Shows both inline and modular assignment patterns
   - Includes comprehensive README with troubleshooting guide
 - Missing `examples/resources/database_workspace/` with multiple cloud provider examples
-- `.pre-commit-config.yaml` already existed (verified complete)
 
 ## [0.1.1] - 2025-10-30
 
@@ -204,24 +225,6 @@ resource "cyberarksia_database_secret" "rds_iam" {
 ## [0.1.0] - 2025-10-30
 
 ### Added
-- Comprehensive acceptance test coverage for policy resources
-  - `database_policy_resource_test.go`: 12 tests covering CRUD, conditions, time frames, inline assignments, validation, and ForceNew behavior
-  - `database_policy_principal_assignment_resource_test.go`: 10 tests covering principal types (USER, GROUP, ROLE), composite IDs, and assignments
-  - `policy_workspace_assignment_resource_test.go`: 14 tests covering all 6 authentication methods (db_auth, ldap_auth, oracle_auth, mongo_auth, sqlserver_auth, rds_iam_user_auth) and composite IDs
-- Complete profile factory test coverage
-  - Added tests for all 4 remaining authentication methods: OracleAuth, MongoAuth, SQLServerAuth, RDSIAMUserAuth
-  - Total coverage: 14 tests for all 6 authentication profile types
-- Complete validator test coverage (100% coverage)
-  - `policy_status_validator_test.go`: 16 test cases validating "active"/"suspended" status values
-  - `principal_type_validator_test.go`: 22 test cases validating USER/GROUP/ROLE types
-  - `location_type_validator_test.go`: 20 test cases validating "FQDN/IP" location type
-  - `database_engine_validator_test.go`: 67 test cases covering 60+ database engines (AWS, Azure, GCP, on-premise, Atlas)
-  - `uuid_validator_test.go`: 27 test cases validating UUID v4 format
-  - `email_like_validator_test.go`: 45 test cases validating email-like principal names
-- LLM Testing Guide in CLAUDE.md for automated CRUD operation validation
-  - Structured test plans for Certificate and Database Workspace resources
-  - Validation checklists and expected outputs
-  - Common testing patterns and automation sequences
 - Initial provider implementation
 - Certificate resource (`cyberarksia_certificate`)
   - Create, read, update, delete TLS/SSL certificates
@@ -253,14 +256,8 @@ resource "cyberarksia_database_secret" "rds_iam" {
 - Provider authentication using CyberArk Identity OAuth2
 - ARK SDK integration with automatic token refresh
 - Comprehensive error handling and retry logic with exponential backoff
-- Acceptance test suite with 69 tests
+- Acceptance test suite
 - Example configurations for common use cases
-
-### Changed
-- Increased total acceptance test count from 33 to 69 tests
-- Policy resource testing coverage increased from 0% to comprehensive (36 new tests)
-- Validator test coverage increased from 22.9% to 100.0% (197+ new test cases)
-- Total unit test functions increased from 34 to 47
 
 ### Security
 - All sensitive fields (passwords, secrets, certificate bodies) properly marked as sensitive
@@ -274,38 +271,10 @@ resource "cyberarksia_database_secret" "rds_iam" {
 - Troubleshooting guide
 - Multiple example configurations
 
-### Added
-- LLM Testing Guide in CLAUDE.md for automated CRUD operation validation
-  - Structured test plans for Certificate and Database Workspace resources
-  - Validation checklists and expected outputs
-  - Common testing patterns and automation sequences
-- Initial provider implementation
-- Certificate resource (`cyberarksia_certificate`)
-  - Create, read, update, delete TLS/SSL certificates
-  - Support for PEM and DER formats
-  - Automatic X.509 metadata extraction
-  - Label-based organization
-- Database workspace resource (`cyberarksia_database_workspace`)
-  - Configure database targets with 60+ supported engines
-  - Multi-cloud support (AWS, Azure, GCP, Atlas, on-premise)
-  - Certificate-based authentication
-  - Network segmentation support
-  - Authentication method configuration
-- Provider authentication using CyberArk Identity OAuth2
-- ARK SDK integration with automatic token refresh
-- Comprehensive error handling and retry logic with exponential backoff
-- Acceptance test suite
-- Example configurations for common use cases
-
 ---
 
 ## Version History Notes
 
 This provider was developed using a test-driven approach with comprehensive planning and specification documents available in the `specs/` directory.
-
-### Development Phases
-- **Phase 1**: Project foundation and authentication
-- **Phase 2**: Certificate resource implementation
-- **Phase 3**: Database workspace resource (renamed from database_target)
 
 For detailed architectural decisions and implementation insights, see [docs/development-history.md](docs/development-history.md).

--- a/docs/resources/vm_policy.md
+++ b/docs/resources/vm_policy.md
@@ -41,12 +41,12 @@ resource "cyberarksia_vm_policy" "basic_servers" {
   description   = "Access policy for production on-premises servers"
 
   # Required: At least one principal assignment at policy creation
-  principal {
-    principal_id          = data.cyberarksia_principal.vm_admin.principal_id
-    principal_name        = data.cyberarksia_principal.vm_admin.principal_name
+  principals {
+    principal_id          = data.cyberarksia_principal.vm_admin.id
+    principal_name        = data.cyberarksia_principal.vm_admin.name
     principal_type        = data.cyberarksia_principal.vm_admin.principal_type
-    source_directory_name = data.cyberarksia_principal.vm_admin.source_directory_name
-    source_directory_id   = data.cyberarksia_principal.vm_admin.source_directory_id
+    source_directory_name = data.cyberarksia_principal.vm_admin.directory_name
+    source_directory_id   = data.cyberarksia_principal.vm_admin.directory_id
   }
 
   # Connection behavior: SSH with specific username
@@ -351,6 +351,34 @@ For cloud-specific and RDP configurations, see:
 - [GCP Policy](../../examples/resources/cyberarksia_vm_policy/gcp_policy.tf) - Projects, VPCs, labels
 - [RDP Policy](../../examples/resources/cyberarksia_vm_policy/rdp_policy.tf) - Local/domain ephemeral users
 
+## Cloud Target Format Requirements
+
+When targeting cloud resources, use these exact formats:
+
+### AWS (`aws_targets`)
+
+| Field | Format | Example |
+|-------|--------|---------|
+| `account_ids` | 12-digit number | `123456789012` |
+| `vpc_ids` | `vpc-` + 8 or 17 alphanumeric chars | `vpc-12345678`, `vpc-0a1b2c3d4e5f6789a` |
+
+### Azure (`azure_targets`)
+
+| Field | Format | Example |
+|-------|--------|---------|
+| `subscriptions` | UUID (32 chars in 5 hyphen-separated groups) | `759a039e-dc44-4762-9f40-2696323c2fa5` |
+| `resource_groups` | Full ARM path | `/subscriptions/<id>/resourceGroups/<name>` |
+| `vnet_ids` | Full ARM path | `/subscriptions/<id>/resourceGroups/<rg>/providers/Microsoft.Network/virtualNetworks/<name>` |
+
+**Common Error**: Using just the resource group name (e.g., `my-rg`) instead of the full ARM path results in: `invalid azure resource group`.
+
+### GCP (`gcp_targets`)
+
+| Field | Format | Example |
+|-------|--------|---------|
+| `projects` | 3-60 chars, lowercase letters/numbers/hyphens | `my-project-123` |
+| `vpc_ids` | Full path format | `projects/<project>/global/networks/<network>` |
+
 ## Troubleshooting
 
 | Error | Cause | Resolution |
@@ -359,3 +387,4 @@ For cloud-specific and RDP configurations, see:
 | "at least 1 principal" | Cannot remove last principal | Add another principal first, or delete the policy |
 | "unsupported workspace type" | Azure policy SDK limitation | Provider handles this automatically |
 | Multiple target blocks | Only one location type allowed | Use exactly one of: `fqdn_ip_targets`, `aws_targets`, `azure_targets`, or `gcp_targets` |
+| "invalid azure resource group" | Wrong format for resource_groups | Use full ARM path: `/subscriptions/<id>/resourceGroups/<name>` |

--- a/examples/complete/multi-cloud/README.md
+++ b/examples/complete/multi-cloud/README.md
@@ -1,0 +1,86 @@
+# Multi-Cloud VM Policy Examples
+
+VM access policies for AWS, Azure, GCP, and on-premises infrastructure.
+
+## Prerequisites
+
+1. CyberArk Identity tenant with SIA enabled
+2. Service account with VM policy management permissions
+3. At least one user/group in your identity directory
+
+## Quick Start
+
+```bash
+# Set credentials
+export CYBERARK_USERNAME="your-service-account@cyberark.cloud.12345"
+export CYBERARK_PASSWORD="your-password"
+
+# Initialize
+terraform init
+
+# Deploy AWS policy
+terraform apply -var="principal_name=admin@example.com" -var="aws_account_id=123456789012"
+
+# Or deploy on-premises policy
+terraform apply -var="principal_name=admin@example.com" -var='fqdn_targets=["*.prod.example.com"]'
+```
+
+## Files
+
+| File | Cloud | Description |
+|------|-------|-------------|
+| `provider.tf` | All | Provider config and shared principal lookup |
+| `aws-vm-policy.tf` | AWS | Target by account ID and VPC |
+| `azure-vm-policy.tf` | Azure | Target by subscription and resource group |
+| `gcp-vm-policy.tf` | GCP | Target by project and VPC network |
+| `onprem-vm-policy.tf` | On-prem | Target by FQDN, hostname, IP, or CIDR |
+
+## Target Format Reference
+
+### AWS
+
+```hcl
+aws_targets {
+  account_ids = ["123456789012"]          # 12-digit account ID
+  vpc_ids     = ["vpc-0a1b2c3d4e5f6789a"] # Optional: vpc- prefix
+}
+```
+
+### Azure
+
+**Important**: Use full ARM resource paths, not just names.
+
+```hcl
+azure_targets {
+  subscription_ids = ["759a039e-dc44-4762-9f40-2696323c2fa5"]
+  resource_groups  = ["/subscriptions/759a039e-.../resourceGroups/my-rg"]
+}
+```
+
+### GCP
+
+```hcl
+gcp_targets {
+  project_ids     = ["my-project-123"]
+  vpc_network_ids = ["projects/my-project-123/global/networks/my-vpc"]
+}
+```
+
+### On-Premises (FQDN/IP)
+
+```hcl
+fqdn_targets = [
+  "server1.example.com",     # Specific host
+  "*.prod.example.com",      # Wildcard
+  "192.168.1.100",           # IP address
+  "10.0.0.0/24"              # CIDR range
+]
+```
+
+## Common Errors
+
+| Error | Cause | Fix |
+|-------|-------|-----|
+| `invalid azure resource group` | Using name instead of ARM path | Use full `/subscriptions/.../resourceGroups/name` path |
+| `principal not found` | User/group doesn't exist | Verify principal exists in CyberArk Identity |
+| `invalid AWS account ID` | Wrong format | Must be exactly 12 digits |

--- a/examples/complete/multi-cloud/aws-vm-policy.tf
+++ b/examples/complete/multi-cloud/aws-vm-policy.tf
@@ -1,0 +1,70 @@
+# AWS VM Access Policy Example
+#
+# This example demonstrates VM access policies targeting AWS infrastructure.
+#
+# PREREQUISITES:
+# - AWS account IDs you want to target
+# - (Optional) VPC IDs for more granular targeting
+#
+# USAGE:
+#   terraform apply -var="principal_name=admin@example.com" -var="aws_account_id=123456789012"
+
+# =============================================================================
+# VARIABLES
+# =============================================================================
+
+variable "aws_account_id" {
+  description = "AWS account ID (12 digits) to target"
+  type        = string
+
+  validation {
+    condition     = can(regex("^[0-9]{12}$", var.aws_account_id))
+    error_message = "AWS account ID must be exactly 12 digits"
+  }
+}
+
+variable "aws_vpc_ids" {
+  description = "Optional list of VPC IDs to target (leave empty for all VPCs in account)"
+  type        = list(string)
+  default     = []
+}
+
+# =============================================================================
+# AWS VM POLICY
+# =============================================================================
+
+resource "cyberarksia_vm_policy" "aws_ssh_access" {
+  name          = "aws-ssh-access"
+  description   = "SSH access to AWS EC2 instances"
+  status        = "active"
+  location_type = "AWS"
+  protocols     = ["SSH"]
+
+  # Target AWS resources
+  aws_targets {
+    account_ids = [var.aws_account_id]
+    vpc_ids     = var.aws_vpc_ids
+  }
+
+  # At least one principal is required at creation
+  principals {
+    id   = data.cyberarksia_principal.target_principal.id
+    type = var.principal_type
+  }
+
+  session_timeout = 60 # minutes
+}
+
+# =============================================================================
+# OUTPUTS
+# =============================================================================
+
+output "aws_policy_id" {
+  description = "ID of the created AWS VM policy"
+  value       = cyberarksia_vm_policy.aws_ssh_access.id
+}
+
+output "aws_policy_name" {
+  description = "Name of the created AWS VM policy"
+  value       = cyberarksia_vm_policy.aws_ssh_access.name
+}

--- a/examples/complete/multi-cloud/azure-vm-policy.tf
+++ b/examples/complete/multi-cloud/azure-vm-policy.tf
@@ -1,0 +1,87 @@
+# Azure VM Access Policy Example
+#
+# This example demonstrates VM access policies targeting Azure infrastructure.
+#
+# IMPORTANT: Azure targets require FULL ARM resource paths, not just names.
+# Common error: Using "my-rg" instead of "/subscriptions/.../resourceGroups/my-rg"
+#
+# PREREQUISITES:
+# - Azure subscription ID (UUID format)
+# - Resource group ARM paths (if targeting specific RGs)
+#
+# USAGE:
+#   terraform apply \
+#     -var="principal_name=admin@example.com" \
+#     -var="azure_subscription_id=759a039e-dc44-4762-9f40-2696323c2fa5"
+
+# =============================================================================
+# VARIABLES
+# =============================================================================
+
+variable "azure_subscription_id" {
+  description = "Azure subscription ID (UUID format)"
+  type        = string
+
+  validation {
+    condition     = can(regex("^[0-9a-f]{8}-[0-9a-f]{4}-[0-9a-f]{4}-[0-9a-f]{4}-[0-9a-f]{12}$", var.azure_subscription_id))
+    error_message = "Azure subscription ID must be a valid UUID"
+  }
+}
+
+variable "azure_resource_group_names" {
+  description = "Optional list of resource group NAMES (will be converted to ARM paths)"
+  type        = list(string)
+  default     = []
+}
+
+# =============================================================================
+# LOCAL VALUES
+# =============================================================================
+
+locals {
+  # Convert resource group names to full ARM paths
+  azure_resource_group_paths = [
+    for rg in var.azure_resource_group_names :
+    "/subscriptions/${var.azure_subscription_id}/resourceGroups/${rg}"
+  ]
+}
+
+# =============================================================================
+# AZURE VM POLICY
+# =============================================================================
+
+resource "cyberarksia_vm_policy" "azure_rdp_access" {
+  name          = "azure-rdp-access"
+  description   = "RDP access to Azure VMs"
+  status        = "active"
+  location_type = "Azure"
+  protocols     = ["RDP"]
+
+  # Target Azure resources
+  azure_targets {
+    subscription_ids = [var.azure_subscription_id]
+    resource_groups  = local.azure_resource_group_paths
+  }
+
+  # At least one principal is required at creation
+  principals {
+    id   = data.cyberarksia_principal.target_principal.id
+    type = var.principal_type
+  }
+
+  session_timeout = 60 # minutes
+}
+
+# =============================================================================
+# OUTPUTS
+# =============================================================================
+
+output "azure_policy_id" {
+  description = "ID of the created Azure VM policy"
+  value       = cyberarksia_vm_policy.azure_rdp_access.id
+}
+
+output "azure_resource_group_paths" {
+  description = "Full ARM paths used for resource group targeting"
+  value       = local.azure_resource_group_paths
+}

--- a/examples/complete/multi-cloud/gcp-vm-policy.tf
+++ b/examples/complete/multi-cloud/gcp-vm-policy.tf
@@ -1,0 +1,82 @@
+# GCP VM Access Policy Example
+#
+# This example demonstrates VM access policies targeting GCP infrastructure.
+#
+# PREREQUISITES:
+# - GCP project ID (not project number)
+# - (Optional) VPC network paths for more granular targeting
+#
+# USAGE:
+#   terraform apply -var="principal_name=admin@example.com" -var="gcp_project_id=my-project-123"
+
+# =============================================================================
+# VARIABLES
+# =============================================================================
+
+variable "gcp_project_id" {
+  description = "GCP project ID (not project number)"
+  type        = string
+
+  validation {
+    condition     = can(regex("^[a-z][a-z0-9-]{4,28}[a-z0-9]$", var.gcp_project_id))
+    error_message = "GCP project ID must be 6-30 lowercase letters, digits, or hyphens, starting with a letter"
+  }
+}
+
+variable "gcp_vpc_network_names" {
+  description = "Optional list of VPC network names (will be converted to full paths)"
+  type        = list(string)
+  default     = []
+}
+
+# =============================================================================
+# LOCAL VALUES
+# =============================================================================
+
+locals {
+  # Convert VPC network names to full resource paths
+  gcp_vpc_network_paths = [
+    for vpc in var.gcp_vpc_network_names :
+    "projects/${var.gcp_project_id}/global/networks/${vpc}"
+  ]
+}
+
+# =============================================================================
+# GCP VM POLICY
+# =============================================================================
+
+resource "cyberarksia_vm_policy" "gcp_ssh_access" {
+  name          = "gcp-ssh-access"
+  description   = "SSH access to GCP Compute Engine instances"
+  status        = "active"
+  location_type = "GCP"
+  protocols     = ["SSH"]
+
+  # Target GCP resources
+  gcp_targets {
+    project_ids     = [var.gcp_project_id]
+    vpc_network_ids = local.gcp_vpc_network_paths
+  }
+
+  # At least one principal is required at creation
+  principals {
+    id   = data.cyberarksia_principal.target_principal.id
+    type = var.principal_type
+  }
+
+  session_timeout = 60 # minutes
+}
+
+# =============================================================================
+# OUTPUTS
+# =============================================================================
+
+output "gcp_policy_id" {
+  description = "ID of the created GCP VM policy"
+  value       = cyberarksia_vm_policy.gcp_ssh_access.id
+}
+
+output "gcp_vpc_network_paths" {
+  description = "Full VPC network paths used for targeting"
+  value       = local.gcp_vpc_network_paths
+}

--- a/examples/complete/multi-cloud/onprem-vm-policy.tf
+++ b/examples/complete/multi-cloud/onprem-vm-policy.tf
@@ -1,0 +1,77 @@
+# On-Premises (FQDN/IP) VM Access Policy Example
+#
+# This example demonstrates VM access policies targeting on-premises servers
+# or any infrastructure accessible via FQDN or IP address.
+#
+# SUPPORTED FORMATS:
+# - Specific hostnames: "server1.example.com"
+# - Wildcards: "*.prod.example.com"
+# - IP addresses: "192.168.1.100"
+# - CIDR ranges: "10.0.0.0/24"
+#
+# USAGE:
+#   terraform apply \
+#     -var="principal_name=admin@example.com" \
+#     -var='fqdn_targets=["*.prod.example.com", "bastion.example.com"]'
+
+# =============================================================================
+# VARIABLES
+# =============================================================================
+
+variable "fqdn_targets" {
+  description = "List of FQDNs, hostnames, IPs, or CIDR ranges to target"
+  type        = list(string)
+
+  validation {
+    condition     = length(var.fqdn_targets) > 0
+    error_message = "At least one FQDN target is required"
+  }
+}
+
+variable "onprem_protocols" {
+  description = "Protocols to allow: SSH, RDP, or both"
+  type        = list(string)
+  default     = ["SSH"]
+
+  validation {
+    condition     = alltrue([for p in var.onprem_protocols : contains(["SSH", "RDP"], p)])
+    error_message = "Protocols must be SSH or RDP"
+  }
+}
+
+# =============================================================================
+# ON-PREMISES VM POLICY
+# =============================================================================
+
+resource "cyberarksia_vm_policy" "onprem_access" {
+  name          = "onprem-server-access"
+  description   = "Access to on-premises servers via FQDN/IP"
+  status        = "active"
+  location_type = "FQDN/IP"
+  protocols     = var.onprem_protocols
+
+  # Target specific FQDNs, hostnames, or IP ranges
+  fqdn_targets = var.fqdn_targets
+
+  # At least one principal is required at creation
+  principals {
+    id   = data.cyberarksia_principal.target_principal.id
+    type = var.principal_type
+  }
+
+  session_timeout = 60 # minutes
+}
+
+# =============================================================================
+# OUTPUTS
+# =============================================================================
+
+output "onprem_policy_id" {
+  description = "ID of the created on-premises VM policy"
+  value       = cyberarksia_vm_policy.onprem_access.id
+}
+
+output "onprem_targets" {
+  description = "FQDN/IP targets configured for this policy"
+  value       = var.fqdn_targets
+}

--- a/examples/complete/multi-cloud/provider.tf
+++ b/examples/complete/multi-cloud/provider.tf
@@ -1,0 +1,61 @@
+# Provider configuration for multi-cloud examples
+#
+# PREREQUISITES:
+# 1. CyberArk Identity tenant with SIA enabled
+# 2. Service account with VM policy management permissions
+# 3. At least one user/group configured in your identity directory
+
+terraform {
+  required_providers {
+    cyberarksia = {
+      source  = "aaearon/cyberarksia"
+      version = "~> 0.2"
+    }
+  }
+}
+
+provider "cyberarksia" {
+  # Credentials from environment variables:
+  # export CYBERARK_USERNAME="your-service-account@cyberark.cloud.12345"
+  # export CYBERARK_PASSWORD="your-password"
+}
+
+# =============================================================================
+# VARIABLES - Customize these for your environment
+# =============================================================================
+
+variable "principal_name" {
+  description = "Name of user or group to grant access (e.g., 'admin@example.com' or 'cloud-admins')"
+  type        = string
+}
+
+variable "principal_type" {
+  description = "Type of principal: USER, GROUP, or ROLE"
+  type        = string
+  default     = "USER"
+
+  validation {
+    condition     = contains(["USER", "GROUP", "ROLE"], var.principal_type)
+    error_message = "principal_type must be USER, GROUP, or ROLE"
+  }
+}
+
+# =============================================================================
+# PRINCIPAL LOOKUP
+# =============================================================================
+
+# Look up the principal (user/group/role) that will be granted access
+# This must exist in your CyberArk Identity directory
+data "cyberarksia_principal" "target_principal" {
+  name = var.principal_name
+  type = var.principal_type
+}
+
+# =============================================================================
+# OUTPUTS
+# =============================================================================
+
+output "principal_id" {
+  description = "ID of the looked-up principal"
+  value       = data.cyberarksia_principal.target_principal.id
+}


### PR DESCRIPTION
## Summary

Prepares the provider for v0.2.0 release with improved governance and documentation.

- Fix GoReleaser URLs (was incorrectly referencing `terraform-provider-cyberark-sia`)
- Add PR template and CODEOWNERS for better contribution governance
- Add multi-cloud VM policy examples (AWS, Azure, GCP, on-premises)
- Consolidate CHANGELOG with v0.2.0 content (VM policies, target sets, breaking changes)
- Regenerate vm_policy documentation

## Test plan

- [x] `make validate` passes (after commit)
- [x] Pre-commit hooks pass
- [x] Multi-cloud examples are self-contained with variables
- [x] No broken links to deleted guides directory