### PR TITLE
fix(vm_policy): change principals from List to Set for order-independence

### DIFF
--- a/docs/resources/vm_policy.md
+++ b/docs/resources/vm_policy.md
@@ -118,7 +118,7 @@ output "delegation_classification" {
 - `idle_time` (Number) Session idle timeout in minutes (1-120). Default: 10.
 - `max_session_duration` (Number) Maximum session duration in hours (1-24). Default: 1.
 - `policy_type` (String) Policy type. Valid values: `Recurring` (default), `OnDemand`.
-- `principals` (Block List) Principal assignment (repeatable block). **Required**: At least 1 principal. (see [below for nested schema](#nestedblock--principals))
+- `principals` (Block Set) Principal assignment (repeatable block). **Required**: At least 1 principal. (see [below for nested schema](#nestedblock--principals))
 - `tags` (List of String) List of tags for policy organization (max 20 tags).
 - `time_frame` (Block, Optional) Policy validity period. Optional - if not specified, policy never expires. (see [below for nested schema](#nestedblock--time_frame))
 - `time_zone` (String) Timezone for access conditions (max 50 characters). Supports IANA names (e.g., `America/New_York`) or GMT offsets (e.g., `GMT+05:00`). Default: `GMT`.

--- a/internal/models/vm_policy_models.go
+++ b/internal/models/vm_policy_models.go
@@ -20,7 +20,7 @@ type VMPolicyResourceModel struct {
 
 	// Lists and Objects (larger types)
 	Tags          types.List   `tfsdk:"tags"`          // []string
-	Principals    types.List   `tfsdk:"principals"`    // []PrincipalModel, min 1 required
+	Principals    types.Set    `tfsdk:"principals"`    // []PrincipalModel, min 1 required, order-independent
 	AccessWindow  types.Object `tfsdk:"access_window"` // AccessWindowModel
 	TimeFrame     types.Object `tfsdk:"time_frame"`    // TimeFrameModel
 	Behavior      types.Object `tfsdk:"behavior"`      // BehaviorModel

--- a/internal/provider/vm_policy_resource.go
+++ b/internal/provider/vm_policy_resource.go
@@ -193,10 +193,10 @@ func (r *VMPolicyResource) Schema(ctx context.Context, req resource.SchemaReques
 		},
 
 		Blocks: map[string]schema.Block{
-			"principals": schema.ListNestedBlock{
+			"principals": schema.SetNestedBlock{
 				MarkdownDescription: "Principal assignment (repeatable block). **Required**: At least 1 principal.",
-				Validators: []validator.List{
-					listvalidator.SizeAtLeast(1),
+				Validators: []validator.Set{
+					setvalidator.SizeAtLeast(1),
 				},
 				NestedObject: schema.NestedBlockObject{
 					Attributes: map[string]schema.Attribute{
@@ -1425,7 +1425,7 @@ func buildSDKMetadata(plan models.VMPolicyResourceModel, diags *diag.Diagnostics
 }
 
 // buildSDKPrincipals converts Terraform principals to SDK principals
-func buildSDKPrincipals(ctx context.Context, tfPrincipals types.List, diags *diag.Diagnostics) []uapcommonmodels.ArkUAPPrincipal {
+func buildSDKPrincipals(ctx context.Context, tfPrincipals types.Set, diags *diag.Diagnostics) []uapcommonmodels.ArkUAPPrincipal {
 	if tfPrincipals.IsNull() || tfPrincipals.IsUnknown() {
 		return []uapcommonmodels.ArkUAPPrincipal{}
 	}
@@ -1966,7 +1966,7 @@ func mapSDKPolicyToState(ctx context.Context, sdkPolicy *uapsiavmmodels.ArkUAPSI
 		})
 
 		if len(principalModels) > 0 {
-			principalsList, diagsPrincipals := types.ListValueFrom(ctx, types.ObjectType{
+			principalsList, diagsPrincipals := types.SetValueFrom(ctx, types.ObjectType{
 				AttrTypes: map[string]attr.Type{
 					"principal_id":          types.StringType,
 					"principal_name":        types.StringType,
@@ -1981,8 +1981,8 @@ func mapSDKPolicyToState(ctx context.Context, sdkPolicy *uapsiavmmodels.ArkUAPSI
 				state.Principals = principalsList
 			}
 		} else {
-			// No matching principals - set to typed null list
-			state.Principals = types.ListNull(types.ObjectType{
+			// No matching principals - set to typed null set
+			state.Principals = types.SetNull(types.ObjectType{
 				AttrTypes: map[string]attr.Type{
 					"principal_id":          types.StringType,
 					"principal_name":        types.StringType,
@@ -1993,8 +1993,8 @@ func mapSDKPolicyToState(ctx context.Context, sdkPolicy *uapsiavmmodels.ArkUAPSI
 			})
 		}
 	} else {
-		// No principals from API - set to typed null list
-		state.Principals = types.ListNull(types.ObjectType{
+		// No principals from API - set to typed null set
+		state.Principals = types.SetNull(types.ObjectType{
 			AttrTypes: map[string]attr.Type{
 				"principal_id":          types.StringType,
 				"principal_name":        types.StringType,


### PR DESCRIPTION
## Summary

Changes VM policy `principals` block from List to Set to prevent ordering drift when API returns principals in non-deterministic order.

This mirrors the fix applied to database policies in PR #38.

## Changes

- **Schema**: `ListNestedBlock` → `SetNestedBlock` with `setvalidator.SizeAtLeast(1)`
- **Model**: `types.List` → `types.Set` for `Principals` field
- **Resource**: 
  - `types.ListValueFrom` → `types.SetValueFrom`
  - `types.ListNull` → `types.SetNull`
  - `buildSDKPrincipals` function signature updated

## Files Changed

- `internal/provider/vm_policy_resource.go` - schema and conversion changes
- `internal/models/vm_policy_models.go` - model type change
- `docs/resources/vm_policy.md` - auto-generated documentation

## Testing

- Unit tests pass
- Build succeeds
- Note: Live CRUD validation with VM policy not yet performed (database policy fix was validated in PR #38)